### PR TITLE
Add mempool quint specification 

### DIFF
--- a/quint/mempool/Consensus.qnt
+++ b/quint/mempool/Consensus.qnt
@@ -16,7 +16,7 @@ module Consensus{
       decided: P.mapBy(p => Set())
     }
 
-    // 1. helpers
+    //// helpers
 
     pure def processes(state: ConsensusState): Set[Process] = {
       state.proposed.keys()
@@ -70,7 +70,7 @@ module Consensus{
       }
     }
 
-    // 2. preconditions
+    //// preconditions
 
     pure def mayPropose(state: ConsensusState, p: Process, txs: Set[Tx]): bool = {
       state.processes().contains(p) and not(state.hasProposed(p)) and txs.size() != 0
@@ -80,7 +80,7 @@ module Consensus{
       processes(state).contains(p) and size(state.getProposed()) > 0 and not(state.hasDecided(p))
     }
 
-    // 3. transitions
+    //// transitions
 
     pure def propose(state: ConsensusState, p: Process, txs: Set[Tx]): ConsensusState = {
       val newProposed = state.proposed.set(p, txs)
@@ -96,7 +96,7 @@ module Consensus{
       {decided: newDecided, ...state}
     }
 
-    // 4. state machine
+    //// state machine
 
     var _consensus: ConsensusState
 

--- a/quint/mempool/Consensus.qnt
+++ b/quint/mempool/Consensus.qnt
@@ -58,15 +58,14 @@ module Consensus{
       flatten(mapValues(state.decided))
     }
 
+    // this function is useful when comparing two instances of consensus over time
+    // (as e.g., in the stability invariant of the ledger)
+    // state0 is superseded by state1 when all the processes have made more progress in state1 than in state0.
     pure def isSupersededBy(state0: ConsensusState, state1: ConsensusState): bool = {
       and {
         state0.processes() == state1.processes(),
-	state0.processes().forall(
-	  p =>
-	    or {
-	      not(state0.hasDecided(p)) and state1.hasDecided(p),
-	      state0.hasDecided(p) and state1.hasDecided(p)
-	    }
+        state0.processes().forall(
+          p => not(state0.hasDecided(p) and not(state1.hasDecided(p)))
         )
       }
     }
@@ -88,7 +87,7 @@ module Consensus{
       {proposed: newProposed, ...state}
     }
 
-    // decide any proposed of the values
+    // decide any of the proposed values
     pure def decide(state: ConsensusState, p: Process): ConsensusState = {
       val proposal = state.proposed.get(setChooseSome(state.proposed.keys().filter(x => state.proposed.get(x).size()>0)))
       val decisions = state.decided.keys().filter(x => state.decided.get(x).size()>0)
@@ -129,17 +128,14 @@ module Consensus{
 
     // 5. invariants
         
-    // Validity: a process decides only proposed values and such values are non-empty set of transactions
+    // Validity: a process may only decide proposed values
     pure def consensusValidityInv(state: ConsensusState): bool = {    
         state.processes().forall(
         p => or {
-    	       not(state.hasDecided(p)),
-    	       and {
-                   state.decisionOf(p).size()>0,
-                   state.proposed.keys().filter(q => state.proposed.get(q) == state.decided.get(p)).size()>0
-    	       }
-    	     } 
-      )
+                  not(state.hasDecided(p)),
+                  state.proposed.keys().filter(q => state.proposed.get(q) == state.decided.get(p)).size()>0
+    	        }
+        )
     }
     
     // Agreement: no two processes decide different values

--- a/quint/mempool/Consensus.qnt
+++ b/quint/mempool/Consensus.qnt
@@ -1,5 +1,5 @@
 // -*- mode: Bluespec; -*-
-// The common consensus abstraction where processes agree on some blocks (i.e., set of transactions).
+// The common consensus abstraction for blockchain where processes agree on a block (that is, a set of transactions).
 
 module Consensus{
 
@@ -15,6 +15,8 @@ module Consensus{
       proposed: P.mapBy(p => Set()),
       decided: P.mapBy(p => Set())
     }
+
+    // 1. helpers
 
     pure def processes(state: ConsensusState): Set[Process] = {
       state.proposed.keys()
@@ -56,6 +58,21 @@ module Consensus{
       flatten(mapValues(state.decided))
     }
 
+    pure def isSupersededBy(state0: ConsensusState, state1: ConsensusState): bool = {
+      and {
+        state0.processes() == state1.processes(),
+	state0.processes().forall(
+	  p =>
+	    or {
+	      not(state0.hasDecided(p)) and state1.hasDecided(p),
+	      state0.hasDecided(p) and state1.hasDecided(p)
+	    }
+        )
+      }
+    }
+
+    // 2. preconditions
+
     pure def mayPropose(state: ConsensusState, p: Process, txs: Set[Tx]): bool = {
       state.processes().contains(p) and not(state.hasProposed(p)) and txs.size() != 0
     }
@@ -64,12 +81,14 @@ module Consensus{
       processes(state).contains(p) and size(state.getProposed()) > 0 and not(state.hasDecided(p))
     }
 
+    // 3. transitions
+
     pure def propose(state: ConsensusState, p: Process, txs: Set[Tx]): ConsensusState = {
       val newProposed = state.proposed.set(p, txs)
       {proposed: newProposed, ...state}
     }
 
-    // decide any proposed values
+    // decide any proposed of the values
     pure def decide(state: ConsensusState, p: Process): ConsensusState = {
       val proposal = state.proposed.get(setChooseSome(state.proposed.keys().filter(x => state.proposed.get(x).size()>0)))
       val decisions = state.decided.keys().filter(x => state.decided.get(x).size()>0)
@@ -78,18 +97,48 @@ module Consensus{
       {decided: newDecided, ...state}
     }
 
-    // INVARIANTS
-    
-    // Irrevocability: a process decides at most once
-    // This requires applying Consensus:mayDecide before Consensus:decide.
-    
-    // Validity: a process decides only proposed values
-    pure def consensusValidityInv(state: ConsensusState): bool = {
+    // 4. state machine
+
+    var _consensus: ConsensusState
+
+    action consensusInit = all {
+        _consensus' = newConsensus(PROCESSES)
+    }
+
+    action consensusDoPropose = all {
+      nondet p = oneOf(PROCESSES)
+      nondet txs = oneOf(nonEmptyPowerset(TXS))
+      all {
+        require(_consensus.mayPropose(p, txs)),
+        _consensus' = _consensus.propose(p, txs)
+      }
+    }
+
+    action consensusDoDecide = all {
+      nondet p = oneOf(PROCESSES)
+      all {
+        require(_consensus.mayDecide(p)),
+        _consensus' = _consensus.decide(p)
+      }
+    }
+
+    action consensusStep = any {
+      consensusDoPropose,
+      consensusDoDecide
+    }
+
+    // 5. invariants
+        
+    // Validity: a process decides only proposed values and such values are non-empty set of transactions
+    pure def consensusValidityInv(state: ConsensusState): bool = {    
         state.processes().forall(
         p => or {
-	       not(state.hasDecided(p)),
-	       state.proposed.keys().filter(q => state.proposed.get(q) == state.decided.get(p)).size()>0
-	     } 
+    	       not(state.hasDecided(p)),
+    	       and {
+                   state.decisionOf(p).size()>0,
+                   state.proposed.keys().filter(q => state.proposed.get(q) == state.decided.get(p)).size()>0
+    	       }
+    	     } 
       )
     }
     
@@ -98,82 +147,56 @@ module Consensus{
       size(mapValues(state.decided).filter(x => x.size()>0)) <= 1
     }
 
-}
+    // Irrevocability: a decision always remains the same
+    // temporal consensusIrrevocabilityInv = {
+    //     _consensus.processes().forall(
+    // 	  p => always(not(_consensus.hasDecided(p)) or _consensus.decisionOf(p) == next(_consensus).decisionOf(p))
+    // 	)
+    // }
+    // FIXME. cannot be verified yet
 
-module ConsensusTests {
-
-    import Spells.* from "Spells"
-    import System.* from "System"
-    import Consensus.*
-
-    pure val PROCESSES=Set("alice", "bob", "charlie")
-    pure val TXS=Set("T0", "T1", "T2", "T3")
-
-    var st: ConsensusState
-
-    val invariant: bool = {
-      consensusValidityInv(st) and consensusAgreementInv(st)
-    }
-
-    action init = all {
-        st' = newConsensus(PROCESSES)
-    }
-
-    action doPropose = all {
-      nondet p = oneOf(PROCESSES)
-      nondet txs = oneOf(TXS.powerset())
-      all {
-        require(st.mayPropose(p, txs)),
-        st' = st.propose(p, txs)
+    val consensusInvariant = {
+      and {
+        consensusAgreementInv(_consensus),
+        consensusValidityInv(_consensus)
       }
     }
 
-    action doDecide = all {
+    // 6. tests
+    
+    run proposeTwiceErrorTest = {
       nondet p = oneOf(PROCESSES)
-      all {
-        require(st.mayDecide(p)),
-        st' = st.decide(p)
-      }
-    }
-
-    action step = any {
-      doPropose,
-      doDecide
-    }
-
-    run proposeTwiceError = {
-      nondet p = oneOf(PROCESSES)
-      nondet txs = oneOf(TXS.powerset())
-      init
+      nondet txs = oneOf(nonEmptyPowerset(TXS))
+      consensusInit
       .then(
         all {
-    	  st.propose(p, txs).mayPropose(p, txs),
-    	  st' = st
+    	  _consensus.propose(p, txs).mayPropose(p, txs),
+    	  _consensus' = _consensus
     	})
       .fail()
     }
 
-    run decideNonProposedError = {
-      init
+    run decideNonProposedErrorTest = {
+      consensusInit
       .then(
         all {
-          st.mayDecide(oneOf(PROCESSES)),
-          st' = st
+          _consensus.mayDecide(oneOf(PROCESSES)),
+          _consensus' = _consensus
         })
       .fail()
     }
 
-    run decideProposedSuccess = {
+    run decideProposedSuccessTest = {
       nondet p = oneOf(PROCESSES)
       nondet q = oneOf(PROCESSES)
-      nondet txs0 = oneOf(TXS.powerset())
-      nondet txs1 = oneOf(TXS.powerset())
-      init
-      .then(st' = st.propose(p, txs0).propose(q, txs1))
+      nondet txs0 = oneOf(nonEmptyPowerset(TXS))
+      nondet txs1 = oneOf(nonEmptyPowerset(TXS))
+      consensusInit
+      .then(_consensus' = _consensus.propose(p, txs0).propose(q, txs1))
       .then(
         all {
-    	  st' = st,
-    	  st.mayDecide(p) and st.decide(p).hasDecided(p)
+    	  _consensus' = _consensus,
+    	  _consensus.mayDecide(p) and _consensus.decide(p).hasDecided(p)
         })
     }
 

--- a/quint/mempool/Consensus.qnt
+++ b/quint/mempool/Consensus.qnt
@@ -38,11 +38,11 @@ module Consensus{
 
     pure def mayPropose(state: ConsensusState, p: Process, txs: Set[Tx]): bool = processes(state).contains(p) and not(hasProposed(state, p)) and txs.size()!=0
 
-    pure def mayDecide(state: ConsensusState, p: Process): bool = processes(state).contains(p) and state.hasProposed(p) and not(state.hasDecided(p))
+    pure def mayDecide(state: ConsensusState, p: Process): bool = processes(state).contains(p) and size(getProposed(state)) > 0 and not(state.hasDecided(p))
 
     pure def propose(state: ConsensusState, p: Process, txs: Set[Tx]): ConsensusState = {
       val newProposed = state.proposed.set(p, txs)
-      state.with("proposed", newProposed)
+      {proposed: newProposed, ...state}
     }
 
     // decide any proposed values
@@ -51,7 +51,7 @@ module Consensus{
       val decisions = state.decided.keys().filter(x => state.decided.get(x).size()>0)
       val decision = if (decisions.size()>0) {state.decided.get(oneOf(decisions))}  else {proposal}
       val newDecided = state.decided.set(p, decision)
-      state.with("decided",newDecided)
+      {decided: newDecided, ...state}
     }
 
     // INVARIANTS
@@ -59,18 +59,19 @@ module Consensus{
     // Irrevocability: a process decides at most once
     // This requires applying Consensus:mayDecide before Consensus:decide.
     
-    // Validity: a process decides only submitted values
+    // Validity: a process decides only proposed values
     pure def consensusValidityInv(state: ConsensusState): bool = {
       processes(state).forall(
-        p => not(hasDecided(state, p))
-	     or
-	     state.proposed.keys().filter(q => state.proposed.get(q) == state.decided.get(p)).size()>0
+        p => or {
+	       not(hasDecided(state, p)),
+	       state.proposed.keys().filter(q => state.proposed.get(q) == state.decided.get(p)).size()>0
+	     } 
       )
     }
     
     // Agreement: no two processes decide different values
     pure def consensusAgreementInv(state: ConsensusState): bool = {
-       processes(state).forall(x => processes(state).forall(y => setEqualsOrOneEmpty(state.decided.get(x), state.decided.get(y))))
+      size(mapValues(state.decided).filter(x => x.size()>0)) <= 1
     }
 
 }

--- a/quint/mempool/Consensus.qnt
+++ b/quint/mempool/Consensus.qnt
@@ -16,29 +16,53 @@ module Consensus{
       decided: P.mapBy(p => Set())
     }
 
-    pure def processes(state: ConsensusState): Set[Process] = state.proposed.keys()
+    pure def processes(state: ConsensusState): Set[Process] = {
+      state.proposed.keys()
+    }
 
-    pure def hasProposed(state: ConsensusState, p: Process): bool = state.proposed.get(p).size() > 0
+    pure def hasProposed(state: ConsensusState, p: Process): bool = {
+      state.proposed.get(p).size() > 0
+    }
     
-    pure def hasDecided(state: ConsensusState, p: Process): bool = state.decided.get(p).size() > 0
+    pure def hasDecided(state: ConsensusState, p: Process): bool = {
+      state.decided.get(p).size() > 0
+    }
 
-    pure def isProposed(state: ConsensusState, t: Tx): bool = state.proposed.keys().filter(p => state.proposed.get(p).contains(t)).size() > 0
+    pure def isProposed(state: ConsensusState, t: Tx): bool = {
+      state.proposed.keys().filter(p => state.proposed.get(p).contains(t)).size() > 0
+    }
 
-    pure def isDecided(state: ConsensusState, t: Tx): bool = state.decided.keys().filter(p => state.decided.get(p).contains(t)).size() > 0
+    pure def isDecided(state: ConsensusState, t: Tx): bool = {
+      state.decided.keys().filter(p => state.decided.get(p).contains(t)).size() > 0
+    }
 
-    pure def hasDecision(state: ConsensusState): bool = state.decided.keys().filter(p => state.decided.get(p).size()>0).size() > 0
+    pure def hasDecision(state: ConsensusState): bool = {
+      state.decided.keys().filter(p => state.decided.get(p).size()>0).size() > 0
+    }
 
-    pure def decisionOf(state: ConsensusState, p: Process): Set[Tx] = state.decided.get(p)
+    pure def decisionOf(state: ConsensusState, p: Process): Set[Tx] = {
+      state.decided.get(p)
+    }
 
-    pure def proposalOf(state: ConsensusState, p: Process): Set[Tx] = state.proposed.get(p)
+    pure def proposalOf(state: ConsensusState, p: Process): Set[Tx] = {
+      state.proposed.get(p)
+    }
 
-    pure def getProposed(state: ConsensusState): Set[Tx] = flatten(mapValues(state.proposed))
+    pure def getProposed(state: ConsensusState): Set[Tx] = {
+      flatten(mapValues(state.proposed))
+    }
 
-    pure def getDecided(state: ConsensusState): Set[Tx] = flatten(mapValues(state.decided))
+    pure def getDecided(state: ConsensusState): Set[Tx] = {
+      flatten(mapValues(state.decided))
+    }
 
-    pure def mayPropose(state: ConsensusState, p: Process, txs: Set[Tx]): bool = processes(state).contains(p) and not(hasProposed(state, p)) and txs.size()!=0
+    pure def mayPropose(state: ConsensusState, p: Process, txs: Set[Tx]): bool = {
+      state.processes().contains(p) and not(state.hasProposed(p)) and txs.size() != 0
+    }
 
-    pure def mayDecide(state: ConsensusState, p: Process): bool = processes(state).contains(p) and size(getProposed(state)) > 0 and not(state.hasDecided(p))
+    pure def mayDecide(state: ConsensusState, p: Process): bool = {
+      processes(state).contains(p) and size(state.getProposed()) > 0 and not(state.hasDecided(p))
+    }
 
     pure def propose(state: ConsensusState, p: Process, txs: Set[Tx]): ConsensusState = {
       val newProposed = state.proposed.set(p, txs)
@@ -47,9 +71,9 @@ module Consensus{
 
     // decide any proposed values
     pure def decide(state: ConsensusState, p: Process): ConsensusState = {
-      val proposal = state.proposed.get(oneOf(state.proposed.keys().filter(x => state.proposed.get(x).size()>0)))
+      val proposal = state.proposed.get(setChooseSome(state.proposed.keys().filter(x => state.proposed.get(x).size()>0)))
       val decisions = state.decided.keys().filter(x => state.decided.get(x).size()>0)
-      val decision = if (decisions.size()>0) {state.decided.get(oneOf(decisions))}  else {proposal}
+      val decision = if (decisions.size()>0) {state.decided.get(setChooseSome(decisions))}  else {proposal}
       val newDecided = state.decided.set(p, decision)
       {decided: newDecided, ...state}
     }
@@ -61,9 +85,9 @@ module Consensus{
     
     // Validity: a process decides only proposed values
     pure def consensusValidityInv(state: ConsensusState): bool = {
-      processes(state).forall(
+        state.processes().forall(
         p => or {
-	       not(hasDecided(state, p)),
+	       not(state.hasDecided(p)),
 	       state.proposed.keys().filter(q => state.proposed.get(q) == state.decided.get(p)).size()>0
 	     } 
       )
@@ -99,16 +123,16 @@ module ConsensusTests {
       nondet p = oneOf(PROCESSES)
       nondet txs = oneOf(TXS.powerset())
       all {
-        require(mayPropose(st, p, txs)),
-        st' = propose(st, p, txs)
+        require(st.mayPropose(p, txs)),
+        st' = st.propose(p, txs)
       }
     }
 
     action doDecide = all {
       nondet p = oneOf(PROCESSES)
       all {
-        require(mayDecide(st, p)),
-    	st' = decide(st, p)
+        require(st.mayDecide(p)),
+        st' = st.decide(p)
       }
     }
 
@@ -123,7 +147,7 @@ module ConsensusTests {
       init
       .then(
         all {
-    	  mayPropose(propose(st, p, txs), p, txs),
+    	  st.propose(p, txs).mayPropose(p, txs),
     	  st' = st
     	})
       .fail()
@@ -133,9 +157,9 @@ module ConsensusTests {
       init
       .then(
         all {
-  	  mayDecide(st, oneOf(PROCESSES)),
-	  st' = st
-	})
+          st.mayDecide(oneOf(PROCESSES)),
+          st' = st
+        })
       .fail()
     }
 
@@ -145,11 +169,11 @@ module ConsensusTests {
       nondet txs0 = oneOf(TXS.powerset())
       nondet txs1 = oneOf(TXS.powerset())
       init
-      .then(st' = propose(propose(st, p, txs0), q, txs1))
+      .then(st' = st.propose(p, txs0).propose(q, txs1))
       .then(
         all {
     	  st' = st,
-    	  mayDecide(st, p) and hasDecided(decide(st, p), p)
+    	  st.mayDecide(p) and st.decide(p).hasDecided(p)
         })
     }
 

--- a/quint/mempool/Consensus.qnt
+++ b/quint/mempool/Consensus.qnt
@@ -1,0 +1,155 @@
+// -*- mode: Bluespec; -*-
+// The common consensus abstraction where processes agree on some blocks (i.e., set of transactions).
+
+module Consensus{
+
+    import Spells.* from "Spells"
+    import System.* from "System"
+
+    type ConsensusState = {
+      proposed: Process -> Set[Tx],
+      decided: Process -> Set[Tx]
+    }
+
+    pure def newConsensus(P: Set[Process]): ConsensusState = {
+      proposed: P.mapBy(p => Set()),
+      decided: P.mapBy(p => Set())
+    }
+
+    pure def processes(state: ConsensusState): Set[Process] = state.proposed.keys()
+
+    pure def hasProposed(state: ConsensusState, p: Process): bool = state.proposed.get(p).size() > 0
+    
+    pure def hasDecided(state: ConsensusState, p: Process): bool = state.decided.get(p).size() > 0
+
+    pure def isProposed(state: ConsensusState, t: Tx): bool = state.proposed.keys().filter(p => state.proposed.get(p).contains(t)).size() > 0
+
+    pure def isDecided(state: ConsensusState, t: Tx): bool = state.decided.keys().filter(p => state.decided.get(p).contains(t)).size() > 0
+
+    pure def hasDecision(state: ConsensusState): bool = state.decided.keys().filter(p => state.decided.get(p).size()>0).size() > 0
+
+    pure def decisionOf(state: ConsensusState, p: Process): Set[Tx] = state.decided.get(p)
+
+    pure def proposalOf(state: ConsensusState, p: Process): Set[Tx] = state.proposed.get(p)
+
+    pure def getProposed(state: ConsensusState): Set[Tx] = flatten(mapValues(state.proposed))
+
+    pure def getDecided(state: ConsensusState): Set[Tx] = flatten(mapValues(state.decided))
+
+    pure def mayPropose(state: ConsensusState, p: Process, txs: Set[Tx]): bool = processes(state).contains(p) and not(hasProposed(state, p)) and txs.size()!=0
+
+    pure def mayDecide(state: ConsensusState, p: Process): bool = processes(state).contains(p) and state.hasProposed(p) and not(state.hasDecided(p))
+
+    pure def propose(state: ConsensusState, p: Process, txs: Set[Tx]): ConsensusState = {
+      val newProposed = state.proposed.set(p, txs)
+      state.with("proposed", newProposed)
+    }
+
+    // decide any proposed values
+    pure def decide(state: ConsensusState, p: Process): ConsensusState = {
+      val proposal = state.proposed.get(oneOf(state.proposed.keys().filter(x => state.proposed.get(x).size()>0)))
+      val decisions = state.decided.keys().filter(x => state.decided.get(x).size()>0)
+      val decision = if (decisions.size()>0) {state.decided.get(oneOf(decisions))}  else {proposal}
+      val newDecided = state.decided.set(p, decision)
+      state.with("decided",newDecided)
+    }
+
+    // INVARIANTS
+    
+    // Irrevocability: a process decides at most once
+    // This requires applying Consensus:mayDecide before Consensus:decide.
+    
+    // Validity: a process decides only submitted values
+    pure def consensusValidityInv(state: ConsensusState): bool = {
+      processes(state).forall(
+        p => not(hasDecided(state, p))
+	     or
+	     state.proposed.keys().filter(q => state.proposed.get(q) == state.decided.get(p)).size()>0
+      )
+    }
+    
+    // Agreement: no two processes decide different values
+    pure def consensusAgreementInv(state: ConsensusState): bool = {
+       processes(state).forall(x => processes(state).forall(y => setEqualsOrOneEmpty(state.decided.get(x), state.decided.get(y))))
+    }
+
+}
+
+module ConsensusTests {
+
+    import Spells.* from "Spells"
+    import System.* from "System"
+    import Consensus.*
+
+    pure val PROCESSES=Set("alice", "bob", "charlie")
+    pure val TXS=Set("T0", "T1", "T2", "T3")
+
+    var st: ConsensusState
+
+    val invariant: bool = {
+      consensusValidityInv(st) and consensusAgreementInv(st)
+    }
+
+    action init = all {
+        st' = newConsensus(PROCESSES)
+    }
+
+    action doPropose = all {
+      nondet p = oneOf(PROCESSES)
+      nondet txs = oneOf(TXS.powerset())
+      all {
+        require(mayPropose(st, p, txs)),
+        st' = propose(st, p, txs)
+      }
+    }
+
+    action doDecide = all {
+      nondet p = oneOf(PROCESSES)
+      all {
+        require(mayDecide(st, p)),
+    	st' = decide(st, p)
+      }
+    }
+
+    action step = any {
+      doPropose,
+      doDecide
+    }
+
+    run proposeTwiceError = {
+      nondet p = oneOf(PROCESSES)
+      nondet txs = oneOf(TXS.powerset())
+      init
+      .then(
+        all {
+    	  mayPropose(propose(st, p, txs), p, txs),
+    	  st' = st
+    	})
+      .fail()
+    }
+
+    run decideNonProposedError = {
+      init
+      .then(
+        all {
+  	  mayDecide(st, oneOf(PROCESSES)),
+	  st' = st
+	})
+      .fail()
+    }
+
+    run decideProposedSuccess = {
+      nondet p = oneOf(PROCESSES)
+      nondet q = oneOf(PROCESSES)
+      nondet txs0 = oneOf(TXS.powerset())
+      nondet txs1 = oneOf(TXS.powerset())
+      init
+      .then(st' = propose(propose(st, p, txs0), q, txs1))
+      .then(
+        all {
+    	  st' = st,
+    	  mayDecide(st, p) and hasDecided(decide(st, p), p)
+        })
+    }
+
+}

--- a/quint/mempool/Ledger.qnt
+++ b/quint/mempool/Ledger.qnt
@@ -18,7 +18,7 @@ module Ledger{
       log: List(newConsensus(P))
     }
 
-    // 1. helpers
+    //// helpers
 
     // index of the first null entry
     pure def height(state: LedgerState): int = {
@@ -57,7 +57,7 @@ module Ledger{
       if (state.heightOf(p)==0) false else 0.to(state.heightOf(p)-1).exists(h => state.log[h].isDecided(t))
     }
 
-    // 2. preconditions
+    //// preconditions
 
     pure def maySubmit(state: LedgerState, p: Process, txs: Set[Tx]): bool = {
       state.log[state.heightOf(p)].mayPropose(p, txs)
@@ -67,7 +67,7 @@ module Ledger{
       state.log[state.heightOf(p)].mayDecide(p)
     }
 
-    // 3. transitions
+    //// transitions
 
     pure def submit(state: LedgerState, p: Process, txs: Set[Tx]): LedgerState = {
       val currentConsensus = state.log[heightOf(state,p)]
@@ -85,7 +85,7 @@ module Ledger{
       {log: nextLog.replaceAt(heightOf(state,p), currentConsensus.decide(p)), ...state}
     }
 
-    // 4. state machine
+    //// state machine
 
     var _ledger: LedgerState
 
@@ -115,7 +115,7 @@ module Ledger{
       ledgerDoCommit
     }
 
-    // 5. invariants
+    //// invariants
 
     // Validity: every non-null entry is submitted.
     pure def ledgerValidityInv(state: LedgerState): bool = {
@@ -143,7 +143,7 @@ module Ledger{
       }
     }
 
-    // 6. tests
+    //// tests
     
     run submitTwiceErrorTest = {
       nondet p = oneOf(PROCESSES)

--- a/quint/mempool/Ledger.qnt
+++ b/quint/mempool/Ledger.qnt
@@ -1,7 +1,7 @@
 // -*- mode: Bluespec; -*-
-// A Ledger is a replicated log of blocks (i.e., set of transactions).
+// A Ledger is a replicated log of blocks.
 // The specification below considers that
-// - replication is made with consensus (SMR)
+// - replication is made with consensus (see Consensus.qnt)
 // - idempotence is not granted (that is, two log entries might have transactions in common).
 
 module Ledger{
@@ -17,6 +17,8 @@ module Ledger{
     pure def newLedger(P: Set[Process]): LedgerState = {
       log: List(newConsensus(P))
     }
+
+    // 1. helpers
 
     // index of the first null entry
     pure def height(state: LedgerState): int = {
@@ -39,6 +41,10 @@ module Ledger{
       0.to(state.heightOf(p)).fold(Set(), (s, i) => s.union(state.log[i].proposalOf(p)))
     }
 
+    pure def getCommittedFor(state: LedgerState, p: Process): Set[Tx] = {
+      0.to(state.heightOf(p)).fold(Set(), (s, i) => s.union(state.log[i].decisionOf(p)))
+    }
+
     pure def isSubmitted(state: LedgerState, t: Tx): bool = {
       0.to(state.height()).exists(h => state.log[h].isProposed(t))
     }
@@ -51,6 +57,8 @@ module Ledger{
       if (state.heightOf(p)==0) false else 0.to(state.heightOf(p)-1).exists(h => state.log[h].isDecided(t))
     }
 
+    // 2. preconditions
+
     pure def maySubmit(state: LedgerState, p: Process, txs: Set[Tx]): bool = {
       state.log[state.heightOf(p)].mayPropose(p, txs)
     }
@@ -58,6 +66,8 @@ module Ledger{
     pure def mayCommit(state: LedgerState, p: Process): bool = {
       state.log[state.heightOf(p)].mayDecide(p)
     }
+
+    // 3. transitions
 
     pure def submit(state: LedgerState, p: Process, txs: Set[Tx]): LedgerState = {
       val currentConsensus = state.log[heightOf(state,p)]
@@ -72,100 +82,105 @@ module Ledger{
       } else {
     	  state.log
       }
-      state.with("log", nextLog.replaceAt(heightOf(state,p), currentConsensus.decide(p)))
+      {log: nextLog.replaceAt(heightOf(state,p), currentConsensus.decide(p)), ...state}
     }
 
-    // INVARIANTS
+    // 4. state machine
 
-    // Validity: every non-null entry is submitted
+    var _ledger: LedgerState
+
+    action ledgerInit = all {
+        _ledger' = newLedger(PROCESSES)
+    }
+
+    action ledgerDoSubmit = all {
+      nondet p = oneOf(PROCESSES)
+      nondet txs = oneOf(nonEmptyPowerset(TXS))
+      all {
+        require(_ledger.maySubmit(p, txs)),
+    	_ledger' = _ledger.submit(p, txs)
+      }
+    }
+
+    action ledgerDoCommit = all {
+      nondet p = oneOf(PROCESSES)
+      all {
+        require(_ledger.mayCommit(p)),
+        _ledger' = _ledger.commit(p)
+      }
+    }
+
+    action ledgerStep = any {
+      ledgerDoSubmit,
+      ledgerDoCommit
+    }
+
+    // 5. invariants
+
+    // Validity: every non-null entry is submitted.
     pure def ledgerValidityInv(state: LedgerState): bool = {
       0.to(state.height()).forall(h => consensusValidityInv(state.log[h]))
     }
     
-    // Total Order: for any two processes, entries are prefix one from another
+    // Total Order: for any two processes, entries are prefix one from another.
     pure def ledgerOrdertInv(state: LedgerState): bool = {
       0.to(state.height()-1).forall(h => consensusAgreementInv(state.log[h]))
     }
 
-}
+    // Stability: for every process, its entry always grows.
+    // temporal ledgerStabilityInv = {
+    //   and {
+    //     _ledger.height() <= next(_ledger.height()),	
+    //     0.to(_ledger.height()).forall(h => _ledger.log[h].isSupersededBy(next(_ledger.log[h])))
+    //   }
+    // }
+    // FIXME. cannot be verified yet
 
-module LedgerTests {
-
-    import Spells.* from "Spells"
-    import System.* from "System"
-    import Ledger.*
-
-    pure val PROCESSES=Set("alice", "bob", "charlie")
-    pure val TXS=Set("T0", "T1", "T2", "T3")
-
-    var st: LedgerState
-
-    val invariant: bool = {
-      ledgerValidityInv(st) and ledgerOrdertInv(st)
-    }
-
-    action init = all {
-        st' = newLedger(PROCESSES)
-    }
-
-    action doSubmit = all {
-      nondet p = oneOf(PROCESSES)
-      nondet txs = oneOf(TXS.powerset())
-      all {
-        require(st.maySubmit(p, txs)),
-    	st' = st.submit(p, txs)
+    val ledgerInvariant = {
+      and {
+        ledgerValidityInv(_ledger),
+        ledgerOrdertInv(_ledger)
       }
     }
 
-    action doCommit = all {
+    // 6. tests
+    
+    run submitTwiceErrorTest = {
       nondet p = oneOf(PROCESSES)
-      all {
-        require(st.mayCommit(p)),
-        st' = st.commit(p)
-      }
-    }
-
-    action step = any {
-      doSubmit,
-      doCommit
-    }
-
-    run submitTwiceError = {
-      nondet p = oneOf(PROCESSES)
-      nondet txs = oneOf(TXS.powerset())
-      init
+      nondet txs = oneOf(nonEmptyPowerset(TXS))
+      ledgerInit
       .then(
         all {
-          st.submit(p, txs).maySubmit(p, txs),
-          st'=st
+          _ledger.submit(p, txs).maySubmit(p, txs),
+          _ledger'=_ledger
        }
       )
       .fail()
     }
 
-    run commitNonSubmittedError = {
+    run commitNonSubmittedErrorTest = {
       nondet p = oneOf(PROCESSES)
-      init
+      ledgerInit
       .then(
         all {
-    	  st.mayCommit(p),
-          st'=st
+    	  _ledger.mayCommit(p),
+          _ledger'=_ledger
         }
       )
       .fail()
     }
 
-    run commitSubmittedSuccess = {
+    run commitSubmittedSuccessTest = {
       nondet p = oneOf(PROCESSES)
       nondet q = oneOf(PROCESSES)
-      nondet txs0 = oneOf(TXS.powerset())
-      nondet txs1 = oneOf(TXS.powerset())
-      init
-      .then(st' = st.submit(p, txs0).submit(q, txs1))
+      nondet txs0 = oneOf(nonEmptyPowerset(TXS))
+      nondet txs1 = oneOf(nonEmptyPowerset(TXS))
+      ledgerInit
+      .then(_ledger' = _ledger.submit(p, txs0).submit(q, txs1))
       .then(
         all {
-          st.mayCommit(p) and heightOf(st.commit(p), p)==1,
-          st'=st
+          _ledger.mayCommit(p) and heightOf(_ledger.commit(p), p)==1,
+          _ledger'=_ledger
        }
       )
     }

--- a/quint/mempool/Ledger.qnt
+++ b/quint/mempool/Ledger.qnt
@@ -1,0 +1,161 @@
+// -*- mode: Bluespec; -*-
+// A Ledger is a replicated log of blocks (i.e., set of transactions).
+// The specification below considers that
+// - replication is made with consensus (SMR)
+// - idempotence is not granted (that is, two log entries might have transactions in common).
+
+module Ledger{
+
+    import Spells.* from "Spells"
+    import System.* from "System"
+    import Consensus.* from "Consensus"
+
+    type LedgerState = {
+      log: List[ConsensusState],
+    }
+
+    pure def newLedger(P: Set[Process]): LedgerState = {log: List(newConsensus(P))}
+
+    // index of the first null entry
+    pure def height(state: LedgerState): int = length(state.log.select(s => s.hasDecision()))
+
+    pure def heightOf(state: LedgerState, p: Process): int = length(state.log.select(s => s.hasDecided(p)))
+
+    pure def entry(state: LedgerState, p: Process, i: int): Set[Tx] = state.log[i].decisionOf(p)
+
+    pure def lastEntry(state: LedgerState, p: Process): Set[Tx] = entry(state, p, heightOf(state, p)-1)
+
+    pure def getSubmittedFor(state: LedgerState, p: Process): Set[Tx] = 0.to(heightOf(state, p)).fold(Set(), (s, i) => s.union(proposalOf(state.log[i],p)))
+
+    pure def isSubmitted(state: LedgerState, t: Tx): bool = 0.to(height(state)).exists(h => isProposed(state.log[h], t))
+
+    pure def isCommitted(state: LedgerState, t: Tx): bool = {
+      if (height(state)==0) false else 0.to(height(state)-1).exists(i => isDecided(state.log[i], t))
+    }
+
+    pure def isCommittedFor(state: LedgerState, p: Process, t: Tx): bool = {
+      if (heightOf(state, p)==0) false else 0.to(heightOf(state, p)-1).exists(h => isDecided(state.log[h], t))
+    }
+
+    pure def maySubmit(state: LedgerState, p: Process, txs: Set[Tx]): bool = {
+      val currentConsensus = state.log[heightOf(state,p)]
+      txs.size()>0 and not(currentConsensus.hasProposed(p))
+    }
+
+    pure def mayCommit(state: LedgerState, p: Process): bool = {
+      val currentConsensus = state.log[heightOf(state,p)]
+      currentConsensus.hasProposed(p) and not(currentConsensus.hasDecided(p))
+    }
+
+    pure def submit(state: LedgerState, p: Process, txs: Set[Tx]): LedgerState = {
+      val currentConsensus = state.log[heightOf(state,p)]
+      val nextLog = state.log.replaceAt(heightOf(state,p), currentConsensus.propose(p, txs))
+      state.with("log", nextLog)
+    }
+
+    pure def commit(state: LedgerState, p: Process): LedgerState = {
+      val currentConsensus = state.log[heightOf(state,p)]
+      val nextLog = if (heightOf(state, p) == height(state)) {
+          state.log.append(newConsensus(processes(state.log[0])))
+      }else{
+    	  state.log
+      }
+      state.with("log", nextLog.replaceAt(heightOf(state,p), currentConsensus.decide(p)))
+    }
+
+    // INVARIANTS
+
+    // Validity: every entry is submitted
+    pure def ledgerValidityInv(state: LedgerState): bool = {
+      0.to(height(state)).forall(h => consensusValidityInv(state.log[h]))
+    }
+    
+    // Order: for any two processes, entries are prefix one from another
+    pure def ledgerOrdertInv(state: LedgerState): bool = {
+      0.to(height(state)-1).forall(h => consensusAgreementInv(state.log[h]))
+    }
+
+}
+
+module LedgerTests {
+
+    import Spells.* from "Spells"
+    import System.* from "System"
+    import Ledger.*
+
+    pure val PROCESSES=Set("alice", "bob", "charlie")
+    pure val TXS=Set("T0", "T1", "T2", "T3")
+
+    var st: LedgerState
+
+    val invariant: bool = {
+      ledgerValidityInv(st) and ledgerOrdertInv(st)
+    }
+
+    action init = all {
+        st' = newLedger(PROCESSES)
+    }
+
+    action doSubmit = all {
+      nondet p = oneOf(PROCESSES)
+      nondet txs = oneOf(TXS.powerset())
+      all {
+        require(maySubmit(st, p, txs)),
+    	st' = submit(st, p, txs)
+      }
+    }
+
+    action doCommit = all {
+      nondet p = oneOf(PROCESSES)
+      all {
+        require(mayCommit(st, p)),
+	st' = commit(st, p)
+      }
+    }
+
+    action step = any {
+      doSubmit,
+      doCommit
+    }
+
+    run submitTwiceError = {
+      nondet p = oneOf(PROCESSES)
+      nondet txs = oneOf(TXS.powerset())
+      init
+      .then(
+        all {
+	  maySubmit(submit(st, p, txs), p, txs),
+	  st'=st
+	}
+      )
+      .fail()
+    }
+
+    run commitNonSubmittedError = {
+      nondet p = oneOf(PROCESSES)
+      init
+      .then(
+        all {
+    	  mayCommit(st, p),
+	  st'=st
+	}
+      )
+      .fail()
+    }
+
+    run commitSubmittedSuccess = {
+      nondet p = oneOf(PROCESSES)
+      nondet q = oneOf(PROCESSES)
+      nondet txs0 = oneOf(TXS.powerset())
+      nondet txs1 = oneOf(TXS.powerset())
+      init
+      .then(st'=submit(submit(st, p, txs0), q, txs1))
+      .then(
+        all {
+	  mayCommit(st, p) and heightOf(commit(st, p), p)==1,
+	  st'=st
+	}
+      )
+    }
+
+}

--- a/quint/mempool/Ledger.qnt
+++ b/quint/mempool/Ledger.qnt
@@ -50,7 +50,7 @@ module Ledger{
     pure def submit(state: LedgerState, p: Process, txs: Set[Tx]): LedgerState = {
       val currentConsensus = state.log[heightOf(state,p)]
       val nextLog = state.log.replaceAt(heightOf(state,p), currentConsensus.propose(p, txs))
-      state.with("log", nextLog)
+      {log: nextLog, ...state}
     }
 
     pure def commit(state: LedgerState, p: Process): LedgerState = {
@@ -65,12 +65,12 @@ module Ledger{
 
     // INVARIANTS
 
-    // Validity: every entry is submitted
+    // Validity: every non-null entry is submitted
     pure def ledgerValidityInv(state: LedgerState): bool = {
       0.to(height(state)).forall(h => consensusValidityInv(state.log[h]))
     }
     
-    // Order: for any two processes, entries are prefix one from another
+    // Total Order: for any two processes, entries are prefix one from another
     pure def ledgerOrdertInv(state: LedgerState): bool = {
       0.to(height(state)-1).forall(h => consensusAgreementInv(state.log[h]))
     }

--- a/quint/mempool/Ledger.qnt
+++ b/quint/mempool/Ledger.qnt
@@ -98,7 +98,7 @@ module Ledger{
       nondet txs = oneOf(nonEmptyPowerset(TXS))
       all {
         require(_ledger.maySubmit(p, txs)),
-    	_ledger' = _ledger.submit(p, txs)
+        _ledger' = _ledger.submit(p, txs)
       }
     }
 
@@ -163,7 +163,7 @@ module Ledger{
       ledgerInit
       .then(
         all {
-    	  _ledger.mayCommit(p),
+          _ledger.mayCommit(p),
           _ledger'=_ledger
         }
       )

--- a/quint/mempool/Ledger.qnt
+++ b/quint/mempool/Ledger.qnt
@@ -14,37 +14,49 @@ module Ledger{
       log: List[ConsensusState],
     }
 
-    pure def newLedger(P: Set[Process]): LedgerState = {log: List(newConsensus(P))}
+    pure def newLedger(P: Set[Process]): LedgerState = {
+      log: List(newConsensus(P))
+    }
 
     // index of the first null entry
-    pure def height(state: LedgerState): int = length(state.log.select(s => s.hasDecision()))
+    pure def height(state: LedgerState): int = {
+      length(state.log.select(s => s.hasDecision()))
+    }
 
-    pure def heightOf(state: LedgerState, p: Process): int = length(state.log.select(s => s.hasDecided(p)))
+    pure def heightOf(state: LedgerState, p: Process): int = {
+      length(state.log.select(s => s.hasDecided(p)))
+    }
 
-    pure def entry(state: LedgerState, p: Process, i: int): Set[Tx] = state.log[i].decisionOf(p)
+    pure def entry(state: LedgerState, p: Process, i: int): Set[Tx] = {
+      state.log[i].decisionOf(p)
+    }
 
-    pure def lastEntry(state: LedgerState, p: Process): Set[Tx] = entry(state, p, heightOf(state, p)-1)
+    pure def lastEntry(state: LedgerState, p: Process): Set[Tx] = {
+      entry(state, p, state.heightOf(p)-1)
+    }
 
-    pure def getSubmittedFor(state: LedgerState, p: Process): Set[Tx] = 0.to(heightOf(state, p)).fold(Set(), (s, i) => s.union(proposalOf(state.log[i],p)))
+    pure def getSubmittedFor(state: LedgerState, p: Process): Set[Tx] = {
+      0.to(state.heightOf(p)).fold(Set(), (s, i) => s.union(state.log[i].proposalOf(p)))
+    }
 
-    pure def isSubmitted(state: LedgerState, t: Tx): bool = 0.to(height(state)).exists(h => isProposed(state.log[h], t))
+    pure def isSubmitted(state: LedgerState, t: Tx): bool = {
+      0.to(state.height()).exists(h => state.log[h].isProposed(t))
+    }
 
     pure def isCommitted(state: LedgerState, t: Tx): bool = {
-      if (height(state)==0) false else 0.to(height(state)-1).exists(i => isDecided(state.log[i], t))
+      if (state.height()==0) false else 0.to(state.height()-1).exists(i => state.log[i].isDecided(t))
     }
 
     pure def isCommittedFor(state: LedgerState, p: Process, t: Tx): bool = {
-      if (heightOf(state, p)==0) false else 0.to(heightOf(state, p)-1).exists(h => isDecided(state.log[h], t))
+      if (state.heightOf(p)==0) false else 0.to(state.heightOf(p)-1).exists(h => state.log[h].isDecided(t))
     }
 
     pure def maySubmit(state: LedgerState, p: Process, txs: Set[Tx]): bool = {
-      val currentConsensus = state.log[heightOf(state,p)]
-      txs.size()>0 and not(currentConsensus.hasProposed(p))
+      state.log[state.heightOf(p)].mayPropose(p, txs)
     }
 
     pure def mayCommit(state: LedgerState, p: Process): bool = {
-      val currentConsensus = state.log[heightOf(state,p)]
-      currentConsensus.hasProposed(p) and not(currentConsensus.hasDecided(p))
+      state.log[state.heightOf(p)].mayDecide(p)
     }
 
     pure def submit(state: LedgerState, p: Process, txs: Set[Tx]): LedgerState = {
@@ -54,10 +66,10 @@ module Ledger{
     }
 
     pure def commit(state: LedgerState, p: Process): LedgerState = {
-      val currentConsensus = state.log[heightOf(state,p)]
-      val nextLog = if (heightOf(state, p) == height(state)) {
+      val currentConsensus = state.log[state.heightOf(p)]
+      val nextLog = if (state.heightOf(p) == state.height()) {
           state.log.append(newConsensus(processes(state.log[0])))
-      }else{
+      } else {
     	  state.log
       }
       state.with("log", nextLog.replaceAt(heightOf(state,p), currentConsensus.decide(p)))
@@ -67,12 +79,12 @@ module Ledger{
 
     // Validity: every non-null entry is submitted
     pure def ledgerValidityInv(state: LedgerState): bool = {
-      0.to(height(state)).forall(h => consensusValidityInv(state.log[h]))
+      0.to(state.height()).forall(h => consensusValidityInv(state.log[h]))
     }
     
     // Total Order: for any two processes, entries are prefix one from another
     pure def ledgerOrdertInv(state: LedgerState): bool = {
-      0.to(height(state)-1).forall(h => consensusAgreementInv(state.log[h]))
+      0.to(state.height()-1).forall(h => consensusAgreementInv(state.log[h]))
     }
 
 }
@@ -100,16 +112,16 @@ module LedgerTests {
       nondet p = oneOf(PROCESSES)
       nondet txs = oneOf(TXS.powerset())
       all {
-        require(maySubmit(st, p, txs)),
-    	st' = submit(st, p, txs)
+        require(st.maySubmit(p, txs)),
+    	st' = st.submit(p, txs)
       }
     }
 
     action doCommit = all {
       nondet p = oneOf(PROCESSES)
       all {
-        require(mayCommit(st, p)),
-	st' = commit(st, p)
+        require(st.mayCommit(p)),
+        st' = st.commit(p)
       }
     }
 
@@ -124,9 +136,9 @@ module LedgerTests {
       init
       .then(
         all {
-	  maySubmit(submit(st, p, txs), p, txs),
-	  st'=st
-	}
+          st.submit(p, txs).maySubmit(p, txs),
+          st'=st
+       }
       )
       .fail()
     }
@@ -136,9 +148,9 @@ module LedgerTests {
       init
       .then(
         all {
-    	  mayCommit(st, p),
-	  st'=st
-	}
+    	  st.mayCommit(p),
+          st'=st
+        }
       )
       .fail()
     }
@@ -149,12 +161,12 @@ module LedgerTests {
       nondet txs0 = oneOf(TXS.powerset())
       nondet txs1 = oneOf(TXS.powerset())
       init
-      .then(st'=submit(submit(st, p, txs0), q, txs1))
+      .then(st' = st.submit(p, txs0).submit(q, txs1))
       .then(
         all {
-	  mayCommit(st, p) and heightOf(commit(st, p), p)==1,
-	  st'=st
-	}
+          st.mayCommit(p) and heightOf(st.commit(p), p)==1,
+          st'=st
+       }
       )
     }
 

--- a/quint/mempool/Mempool.qnt
+++ b/quint/mempool/Mempool.qnt
@@ -96,7 +96,7 @@ module MempoolTests {
         require(isValid(ledger, p, t)),
 	ledger' = ledger,
         mempool' = add(mempool, p, t),
-	hmempool' = hmempool
+	hmempool' = hmempool.set(p, hmempool.get(p).union(Set(t)))
       }
     }
 
@@ -106,7 +106,7 @@ module MempoolTests {
         require(txs.forall(t => isValid(ledger, p, t)) and maySubmit(ledger, p, txs)),
 	ledger' = submit(ledger, p, txs),
       	mempool' = mempool,
-	hmempool' = hmempool.set(p, hmempool.get(p).union(txs))
+	hmempool' = hmempool
       }
     }
 

--- a/quint/mempool/Mempool.qnt
+++ b/quint/mempool/Mempool.qnt
@@ -8,9 +8,8 @@ module ABCI {
     import System.* from "System"
     import Ledger.* from "Ledger"
 
-    // a transaction is committed at most once
     pure def isValid(l: LedgerState, p: Process, t: Tx): bool = {
-      not(isCommittedFor(l, p, t))
+      true
     }
 
 }
@@ -23,139 +22,144 @@ module Mempool {
     import ABCI.*
 
     type MempoolState = {
-      pool: Process -> Set[Tx],
+      mempool: Process -> Set[Tx],
+      hmempool: Process -> Set[Tx], // history variable
+      ledger: LedgerState
     }
 
-    pure def newMemPool(P: Set[Process]): MempoolState = {
-      pool: P.mapBy(p => Set()),
+    pure def newMempoolState(P: Set[Process]): MempoolState = {
+      ledger: newLedger(P),
+      mempool: P.mapBy(p => Set()),
+      hmempool: P.mapBy(p => Set())
     }
 
-    // 1. helpers
+    //// helpers
 
-    pure def txsAvailable(state: MempoolState, p: Process): Set[Tx] = {
-      state.pool.get(p)
+    pure def txsAvailable(st: MempoolState, p: Process): Set[Tx] = {
+      st.mempool.get(p)
     }
 
-    pure def poolSize(state: MempoolState, p: Process): int = {
-      state.pool.get(p).size()
+    pure def txsSize(st: MempoolState, p: Process): int = {
+      st.mempool.get(p).size()
     }
 
-    pure def reap(state: MempoolState, p: Process, max: int): Set[Tx] = {
-      setSubsetOfAtMost(state.pool.get(p), max)
+    pure def reap(st: MempoolState, p: Process, max: int): Set[Tx] = {
+      setSubsetOfAtMost(st.mempool.get(p), max)
     }
 
-    pure def poolOf(state: MempoolState, p: Process): Set[Tx] = {
-      state.pool.get(p)
+    pure def txsOf(st: MempoolState, p: Process): Set[Tx] = {
+      st.mempool.get(p)
     }
 
-    // 2. preconditions
-    // none, as we use mostly the ones of the ledger 
-
-    // 3. transitions
-
-    pure def add(state: MempoolState, p: Process, txs: Set[Tx]): MempoolState = {
-      {pool: state.pool.set(p, state.pool.get(p).union(txs)), ...state}
+    pure def isValidAndNotCommittedFor(ledger: LedgerState, p: Process, tx: Tx): bool = {
+      isValid(ledger, p, tx) and not(ledger.getCommittedFor(p).contains(tx))
     }
 
-    pure def clear(state: MempoolState, p: Process): MempoolState = {
-      {pool: state.pool.set(p, Set()), ...state}
+    //// conditions
+
+    pure def mayRcvFromClientAt(st: MempoolState, p: Process, txs: Set[Tx]): bool = {
+      and {
+        not(txs.subseteq(st.txsOf(p))), // to avoid stuttering
+        txs.forall(tx => isValidAndNotCommittedFor(st.ledger, p, tx))
+      }
     }
 
-    pure def remove(state: MempoolState, p: Process, t: Tx): MempoolState = {
-      {pool: state.pool.set(p, state.pool.get(p).exclude(Set(t))), ...state}
+    pure def mayRcvFromProcessAt(st: MempoolState, p: Process, q: Process, txs: Set[Tx]): bool = {
+      and {
+        p != q,
+	      not(txs.subseteq(st.txsOf(q))), // to avoid stuttering
+        not(st.ledger.heightOf(p) < st.ledger.heightOf(q)),
+      }
     }
 
-    // remove committed and invalid txs from the mempool
-    pure def update(state: MempoolState, p: Process, l: LedgerState): MempoolState = {
-      {pool: state.pool.set(p, state.pool.get(p).exclude(l.getCommittedFor(p)).filter(t => isValid(l, p, t))), ...state}      
+    pure def maySubmitToLedger(st: MempoolState, p: Process, txs: Set[Tx]) : bool = {
+      and {
+        txs.forall(t => st.ledger.isValid(p, t)),
+	      st.ledger.maySubmit(p, txs)
+      }
     }
 
-    // 4. state machine
+    //// transitions
 
-    var ledger: LedgerState
-    var mempool: MempoolState
-    var hmempool: Process -> Set[Tx] // history variable 
+    pure def add(st: MempoolState, p: Process, txs: Set[Tx]): MempoolState = {
+      val nmempool = st.mempool.set(p, st.mempool.get(p).union(txs))
+      val nhmempool = st.hmempool.set(p, st.hmempool.get(p).union(txs))
+      {mempool: nmempool, hmempool: nhmempool, ...st}
+    }
 
-    val print = {ledger: ledger, mempool: mempool, hmempool: hmempool}
+    pure def commitThenUpdate(st: MempoolState, p: Process): MempoolState = {
+      val nledger = st.ledger.commit(p)
+      val nmempool = st.mempool.set(p, st.mempool.get(p).filter(tx => isValidAndNotCommittedFor(nledger, p, tx)))
+      {mempool: nmempool, ledger: nledger, ...st}
+    }
+
+    //// state machine
+
+    var _state: MempoolState
 
     action init : bool = all {
-      val nledger = newLedger(PROCESSES)
       all {
-        ledger' = nledger,
-        mempool' = newMemPool(PROCESSES),
-        hmempool' = PROCESSES.mapBy(p => Set())
+        _state' = newMempoolState(PROCESSES)
       }
     }
 
-    action doClient(p: Process, t: Tx): bool = all {
-      val txs = Set(t)
+    action doClientThenAdd(p: Process, txs: Set[Tx]): bool = all {
       all {
-        require(isValid(ledger, p, t)),
-        ledger' = ledger,
-        mempool' = mempool.add(p, txs),
-        hmempool' = hmempool.set(p, hmempool.get(p).union(txs))
+        require(_state.mayRcvFromClientAt(p, txs)),
+	      _state' = _state.add(p, txs)        
       }
     }
-
-    action doGossipThenUpdate(p: Process, q: Process): bool = all {
-      val txs = mempool.poolOf(p)
-      val nmempool = mempool.add(q, txs).update(q, ledger)
-      all {
-        require(p != q and txs.size()>0),
-        ledger' = ledger,
-        mempool' = nmempool,
-        hmempool' = hmempool.set(q, hmempool.get(q).union(txs))
-      }
-   }
 
     action doSubmit(p: Process): bool = all {
-      val txs = reap(mempool, p, 1)
+      val txs = reap(_state, p, 1)
       all {
-        require(txs.forall(t => ledger.isValid(p, t)) and ledger.maySubmit(p, txs)),
-        ledger' = ledger.submit(p, txs),
-      	mempool' = mempool,
-        hmempool' = hmempool
+        require(_state.maySubmitToLedger(p, txs)),
+        _state' = {ledger: _state.ledger.submit(p, txs), ..._state}
       }
     }
 
     action doCommitThenUpdate(p: Process): bool = all {
-      val nledger = if (ledger.mayCommit(p)) { ledger.commit(p) } else { ledger }	
-      val nmempool = mempool.update(p, nledger)
       all {
-        require(ledger.mayCommit(p)),
-        ledger' = nledger,
-        mempool' = nmempool,
-        hmempool' = hmempool
+        require(_state.ledger.mayCommit(p)),
+	      _state' = _state.commitThenUpdate(p)
       }
     }
+
+    action doGossipThenAdd(p: Process, q: Process): bool = all {
+      val txs = _state.txsOf(p) // all txs at once
+      all {
+        require(_state.mayRcvFromProcessAt(p, q, txs)),
+	       _state' = _state.add(p, txs)
+      }
+   }
 
     action step: bool = {
       nondet p = oneOf(PROCESSES)
       nondet q = oneOf(PROCESSES)
-      nondet t = oneOf(TXS)
+      nondet txs = Set(oneOf(TXS)) // one at a time
       any {
-        doClient(p,t),
+        doClientThenAdd(p,txs),
         doSubmit(p),
         doCommitThenUpdate(p),
-        doGossipThenUpdate(p,q)
+        doGossipThenAdd(p,q)
       }	
     }
 
-    // 5. invariants
+    //// invariants
     
     // INV1. the mempool is used as an input for the ledger
     val inv1 = {
-      PROCESSES.forall(p => ledger.getSubmittedFor(p).subseteq(hmempool.get(p)))
+      PROCESSES.forall(p => _state.ledger.getSubmittedFor(p).subseteq(_state.hmempool.get(p)))
     }
 
     // INV2. committed transactions are not in the mempool
     val inv2 = {
-      PROCESSES.forall(p => 0.to(ledger.heightOf(p)-1).forall(i =>  ledger.entry(p, i).intersect(mempool.poolOf(p)).size()==0))
+      PROCESSES.forall(p => 0.to(_state.ledger.heightOf(p)-1).forall(i =>  _state.ledger.entry(p, i).intersect(_state.txsOf(p)).size()==0))
     }
 
     // INV3. every transaction in the mempool is valid
     val inv3 = {
-      PROCESSES.forall(p => mempool.poolOf(p).forall(t => ledger.isValid(p, t)))
+      PROCESSES.forall(p => _state.txsOf(p).forall(t => _state.ledger.isValid(p, t)))
     }
     
     // INV4. every transaction that appears in the mempool is eventually committed or forever invalid
@@ -164,10 +168,10 @@ module Mempool {
     // }
     // FIXME. cannot be verified yet
 
-    // Instead, we use the (weaker) invariant below
-    // INV4b. every transaction in hmempool is always committed or if valid then still in the mempool
-     def inv4() = {
-       PROCESSES.forall(p => hmempool.get(p).forall(tx => ledger.isCommittedFor(p, tx) or not(ledger.isValid(p, tx)) or mempool.poolOf(p).contains(tx)))
+    // Instead, we use the (simpler) invariant below
+    // INV4b. every transaction in hmempool is always committed or if valid still in the mempool
+     val inv4() = {
+       PROCESSES.forall(p => _state.hmempool.get(p).forall(tx => _state.ledger.isCommittedFor(p, tx) or not(_state.ledger.isValid(p, tx)) or _state.txsOf(p).contains(tx)))
      }
 
     val allInv = and {
@@ -175,15 +179,15 @@ module Mempool {
       inv2,
       inv3,
       inv4
-   }
+    }
 
-    // 6. tests
+    //// tests
 
     run moveHeightOnceTest = {
       nondet p = oneOf(PROCESSES)
-      nondet t = oneOf(TXS)
+      nondet txs = Set(oneOf(TXS))
       init
-      .then(doClient(p,t))
+      .then(doClientThenAdd(p,txs))
       .then(doSubmit(p))
       .then(doCommitThenUpdate(p))
     }

--- a/quint/mempool/Mempool.qnt
+++ b/quint/mempool/Mempool.qnt
@@ -137,7 +137,7 @@ module Mempool {
         doClient(p,t),
         doSubmit(p),
         doCommitThenUpdate(p),
-	doGossipThenUpdate(p,q)
+        doGossipThenUpdate(p,q)
       }	
     }
 

--- a/quint/mempool/Mempool.qnt
+++ b/quint/mempool/Mempool.qnt
@@ -1,0 +1,172 @@
+// -*- mode: Bluespec; -*-
+// A mempool is a replicated set of transactions which is used as an input by a ledger.
+// Below, we follow the specification given here:
+// https://github.com/cometbft/knowledge-base/blob/main/protocols/mempool-overview.md
+
+module ABCI {
+
+    import System.* from "System"
+    import Ledger.* from "Ledger"
+
+    // a transaction is committed at most once
+    pure def isValid(l: LedgerState, p: Process, t: Tx): bool = {
+      not(isCommittedFor(l, p, t))
+    }
+
+}
+
+module Mempool {
+
+    import Spells.* from "Spells"
+    import System.* from "System"
+    import Ledger.* from "Ledger"
+    import ABCI.*
+
+    type MempoolState = {
+      pool: Process -> Set[Tx],
+    }
+
+    pure def txsAvailable(state: MempoolState, p: Process): Set[Tx] = {
+      state.pool.get(p)
+    }
+
+    pure def poolSize(state: MempoolState, p: Process): int = {
+      state.pool.get(p).size()
+    }
+
+    pure def reap(state: MempoolState, p: Process, max: int): Set[Tx] = {
+      setSubsetOfAtMost(state.pool.get(p), max)
+    }
+
+    pure def poolOf(state: MempoolState, p: Process): Set[Tx] = {
+      state.pool.get(p)
+    }
+
+    pure def newMemPool(P: Set[Process]): MempoolState = {
+      pool: P.mapBy(p => Set()),
+    }
+
+    pure def add(state: MempoolState, p: Process, t: Tx): MempoolState = { // aka. checkTx
+      state.with("pool", state.pool.set(p, state.pool.get(p).union(Set(t))))
+    }
+
+    pure def clear(state: MempoolState, p: Process): MempoolState = {
+      state.with("pool", state.pool.set(p, Set()))
+    }
+
+    pure def remove(state: MempoolState, p: Process, t: Tx): MempoolState = {
+      state.with("pool", state.pool.set(p, state.pool.get(p).exclude(Set(t))))
+    }
+
+    // remove committed and invalid txs from the mempool
+    pure def update(state: MempoolState, p: Process, l: LedgerState, ctxs: Set[Tx]): MempoolState = {
+          state.with("pool", state.pool.set(p, state.pool.get(p).exclude(ctxs).filter(t => isValid(l, p, t))))
+    }
+
+}
+
+module MempoolTests {
+
+    import Spells.* from "Spells"
+    import System.* from "System"
+    import Ledger.* from "Ledger"
+    import Mempool.*
+    import ABCI.*
+
+    pure val PROCESSES=Set("alice", "bob")
+    pure val TXS=Set("T0", "T1", "T2")
+
+    var ledger: LedgerState
+    var mempool: MempoolState
+    var hmempool: Process -> Set[Tx] // history variable 
+
+    val print = {ledger: ledger, mempool: mempool, hmempool: hmempool}
+
+    action init : bool = all {
+      val nledger = newLedger(PROCESSES)
+      all {
+        ledger' = nledger,
+        mempool' = newMemPool(PROCESSES),
+	hmempool' = PROCESSES.mapBy(p => Set())
+      }
+    }
+
+    action doClient(p: Process, t: Tx): bool = all {
+      all {
+        require(isValid(ledger, p, t)),
+	ledger' = ledger,
+        mempool' = add(mempool, p, t),
+	hmempool' = hmempool
+      }
+    }
+
+    action doSubmit(p: Process): bool = all {
+      val txs = reap(mempool, p, 1)
+      all {
+        require(txs.forall(t => isValid(ledger, p, t)) and maySubmit(ledger, p, txs)),
+	ledger' = submit(ledger, p, txs),
+      	mempool' = mempool,
+	hmempool' = hmempool.set(p, hmempool.get(p).union(txs))
+      }
+    }
+
+    action doCommitThenUpdate(p: Process): bool = all {
+      val nledger = if (mayCommit(ledger, p)) commit(ledger, p) else ledger
+      val nmempool = if (heightOf(ledger, p)!=heightOf(nledger, p)) update(mempool, p, nledger, lastEntry(nledger, p)) else mempool
+      all {
+        require(mayCommit(ledger, p)),
+	ledger' = nledger,
+        mempool' = nmempool,
+	hmempool' = hmempool
+      }
+    }
+
+    action step: bool = {
+      nondet p = oneOf(PROCESSES)
+      nondet t = oneOf(TXS)
+      any {
+        doClient(p,t),
+        doSubmit(p),
+	doCommitThenUpdate(p)
+      }	
+    }
+
+
+    // INVARIANTS
+    
+    // INV1. the mempool is used as an input for the ledger
+    def inv1() = {
+      PROCESSES.forall(p => getSubmittedFor(ledger,p).subseteq(hmempool.get(p)))
+    }
+
+    // INV2. committed transactions are not in the mempool
+    def inv2() = {
+      PROCESSES.forall(p => 0.to(heightOf(ledger, p)-1).forall(i =>  entry(ledger, p, i).intersect(poolOf(mempool, p)).size()==0))
+    }
+
+    // INV3. every transaction in the mempool is valid
+    def inv3() = {
+      PROCESSES.forall(p => poolOf(mempool, p).forall(t => isValid(ledger, p, t)))
+    }
+    
+    // INV4. every transaction that appears in the mempool is eventually committed or forever invalid
+    // cannot be checked ftm. with Quint
+    // instead we consider the (weaker) invariant below
+    // INV4b. every transaction in hmempool is always committed or if valid then still in the mempool
+    def inv4() = {
+      PROCESSES.forall(p => hmempool.get(p).forall(tx => isCommittedFor(ledger, p, tx) or not(isValid(ledger, p, tx)) or poolOf(mempool, p).contains(tx)))
+    }
+
+    def allInv = {inv1 and inv2 and inv3 and inv4}
+    
+
+    run moveHeightOnce = {
+      nondet p = oneOf(PROCESSES)
+      nondet t = oneOf(TXS)
+      init
+      .then(doClient(p,t))
+      .then(doSubmit(p))
+      .then(doCommitThenUpdate(p))
+    }
+
+}

--- a/quint/mempool/Mempool.qnt
+++ b/quint/mempool/Mempool.qnt
@@ -87,37 +87,37 @@ module MempoolTests {
       all {
         ledger' = nledger,
         mempool' = newMemPool(PROCESSES),
-	hmempool' = PROCESSES.mapBy(p => Set())
+        hmempool' = PROCESSES.mapBy(p => Set())
       }
     }
 
     action doClient(p: Process, t: Tx): bool = all {
       all {
         require(isValid(ledger, p, t)),
-	ledger' = ledger,
+        ledger' = ledger,
         mempool' = add(mempool, p, t),
-	hmempool' = hmempool.set(p, hmempool.get(p).union(Set(t)))
+        hmempool' = hmempool.set(p, hmempool.get(p).union(Set(t)))
       }
     }
 
     action doSubmit(p: Process): bool = all {
       val txs = reap(mempool, p, 1)
       all {
-        require(txs.forall(t => isValid(ledger, p, t)) and maySubmit(ledger, p, txs)),
-	ledger' = submit(ledger, p, txs),
+        require(txs.forall(t => ledger.isValid(p, t)) and ledger.maySubmit(p, txs)),
+        ledger' = ledger.submit(p, txs),
       	mempool' = mempool,
-	hmempool' = hmempool
+        hmempool' = hmempool
       }
     }
 
     action doCommitThenUpdate(p: Process): bool = all {
-      val nledger = if (mayCommit(ledger, p)) commit(ledger, p) else ledger
-      val nmempool = if (heightOf(ledger, p)!=heightOf(nledger, p)) update(mempool, p, nledger, lastEntry(nledger, p)) else mempool
+      val nledger = ledger.commit(p)
+      val nmempool = mempool.update(p, nledger, nledger.lastEntry(p))
       all {
-        require(mayCommit(ledger, p)),
-	ledger' = nledger,
+        require(ledger.mayCommit(p)),
+        ledger' = nledger,
         mempool' = nmempool,
-	hmempool' = hmempool
+        hmempool' = hmempool
       }
     }
 
@@ -127,7 +127,7 @@ module MempoolTests {
       any {
         doClient(p,t),
         doSubmit(p),
-	doCommitThenUpdate(p)
+        doCommitThenUpdate(p)
       }	
     }
 
@@ -136,17 +136,17 @@ module MempoolTests {
     
     // INV1. the mempool is used as an input for the ledger
     def inv1() = {
-      PROCESSES.forall(p => getSubmittedFor(ledger,p).subseteq(hmempool.get(p)))
+      PROCESSES.forall(p => ledger.getSubmittedFor(p).subseteq(hmempool.get(p)))
     }
 
     // INV2. committed transactions are not in the mempool
     def inv2() = {
-      PROCESSES.forall(p => 0.to(heightOf(ledger, p)-1).forall(i =>  entry(ledger, p, i).intersect(poolOf(mempool, p)).size()==0))
+      PROCESSES.forall(p => 0.to(ledger.heightOf(p)-1).forall(i =>  ledger.entry(p, i).intersect(mempool.poolOf(p)).size()==0))
     }
 
     // INV3. every transaction in the mempool is valid
     def inv3() = {
-      PROCESSES.forall(p => poolOf(mempool, p).forall(t => isValid(ledger, p, t)))
+      PROCESSES.forall(p => mempool.poolOf(p).forall(t => ledger.isValid(p, t)))
     }
     
     // INV4. every transaction that appears in the mempool is eventually committed or forever invalid
@@ -154,11 +154,10 @@ module MempoolTests {
     // instead we consider the (weaker) invariant below
     // INV4b. every transaction in hmempool is always committed or if valid then still in the mempool
     def inv4() = {
-      PROCESSES.forall(p => hmempool.get(p).forall(tx => isCommittedFor(ledger, p, tx) or not(isValid(ledger, p, tx)) or poolOf(mempool, p).contains(tx)))
+      PROCESSES.forall(p => hmempool.get(p).forall(tx => ledger.isCommittedFor(p, tx) or not(ledger.isValid(p, tx)) or mempool.poolOf(p).contains(tx)))
     }
 
     def allInv = {inv1 and inv2 and inv3 and inv4}
-    
 
     run moveHeightOnce = {
       nondet p = oneOf(PROCESSES)

--- a/quint/mempool/Mempool.qnt
+++ b/quint/mempool/Mempool.qnt
@@ -26,6 +26,12 @@ module Mempool {
       pool: Process -> Set[Tx],
     }
 
+    pure def newMemPool(P: Set[Process]): MempoolState = {
+      pool: P.mapBy(p => Set()),
+    }
+
+    // 1. helpers
+
     pure def txsAvailable(state: MempoolState, p: Process): Set[Tx] = {
       state.pool.get(p)
     }
@@ -42,39 +48,29 @@ module Mempool {
       state.pool.get(p)
     }
 
-    pure def newMemPool(P: Set[Process]): MempoolState = {
-      pool: P.mapBy(p => Set()),
-    }
+    // 2. preconditions
+    // none, as we use mostly the ones of the ledger 
 
-    pure def add(state: MempoolState, p: Process, t: Tx): MempoolState = { // aka. checkTx
-      state.with("pool", state.pool.set(p, state.pool.get(p).union(Set(t))))
+    // 3. transitions
+
+    pure def add(state: MempoolState, p: Process, txs: Set[Tx]): MempoolState = {
+      {pool: state.pool.set(p, state.pool.get(p).union(txs)), ...state}
     }
 
     pure def clear(state: MempoolState, p: Process): MempoolState = {
-      state.with("pool", state.pool.set(p, Set()))
+      {pool: state.pool.set(p, Set()), ...state}
     }
 
     pure def remove(state: MempoolState, p: Process, t: Tx): MempoolState = {
-      state.with("pool", state.pool.set(p, state.pool.get(p).exclude(Set(t))))
+      {pool: state.pool.set(p, state.pool.get(p).exclude(Set(t))), ...state}
     }
 
     // remove committed and invalid txs from the mempool
-    pure def update(state: MempoolState, p: Process, l: LedgerState, ctxs: Set[Tx]): MempoolState = {
-          state.with("pool", state.pool.set(p, state.pool.get(p).exclude(ctxs).filter(t => isValid(l, p, t))))
+    pure def update(state: MempoolState, p: Process, l: LedgerState): MempoolState = {
+      {pool: state.pool.set(p, state.pool.get(p).exclude(l.getCommittedFor(p)).filter(t => isValid(l, p, t))), ...state}      
     }
 
-}
-
-module MempoolTests {
-
-    import Spells.* from "Spells"
-    import System.* from "System"
-    import Ledger.* from "Ledger"
-    import Mempool.*
-    import ABCI.*
-
-    pure val PROCESSES=Set("alice", "bob")
-    pure val TXS=Set("T0", "T1", "T2")
+    // 4. state machine
 
     var ledger: LedgerState
     var mempool: MempoolState
@@ -92,13 +88,25 @@ module MempoolTests {
     }
 
     action doClient(p: Process, t: Tx): bool = all {
+      val txs = Set(t)
       all {
         require(isValid(ledger, p, t)),
         ledger' = ledger,
-        mempool' = add(mempool, p, t),
-        hmempool' = hmempool.set(p, hmempool.get(p).union(Set(t)))
+        mempool' = mempool.add(p, txs),
+        hmempool' = hmempool.set(p, hmempool.get(p).union(txs))
       }
     }
+
+    action doGossipThenUpdate(p: Process, q: Process): bool = all {
+      val txs = mempool.poolOf(p)
+      val nmempool = mempool.add(q, txs).update(q, ledger)
+      all {
+        require(p != q and txs.size()>0),
+        ledger' = ledger,
+        mempool' = nmempool,
+        hmempool' = hmempool.set(q, hmempool.get(q).union(txs))
+      }
+   }
 
     action doSubmit(p: Process): bool = all {
       val txs = reap(mempool, p, 1)
@@ -111,8 +119,8 @@ module MempoolTests {
     }
 
     action doCommitThenUpdate(p: Process): bool = all {
-      val nledger = ledger.commit(p)
-      val nmempool = mempool.update(p, nledger, nledger.lastEntry(p))
+      val nledger = if (ledger.mayCommit(p)) { ledger.commit(p) } else { ledger }	
+      val nmempool = mempool.update(p, nledger)
       all {
         require(ledger.mayCommit(p)),
         ledger' = nledger,
@@ -123,43 +131,55 @@ module MempoolTests {
 
     action step: bool = {
       nondet p = oneOf(PROCESSES)
+      nondet q = oneOf(PROCESSES)
       nondet t = oneOf(TXS)
       any {
         doClient(p,t),
         doSubmit(p),
-        doCommitThenUpdate(p)
+        doCommitThenUpdate(p),
+	doGossipThenUpdate(p,q)
       }	
     }
 
-
-    // INVARIANTS
+    // 5. invariants
     
     // INV1. the mempool is used as an input for the ledger
-    def inv1() = {
+    val inv1 = {
       PROCESSES.forall(p => ledger.getSubmittedFor(p).subseteq(hmempool.get(p)))
     }
 
     // INV2. committed transactions are not in the mempool
-    def inv2() = {
+    val inv2 = {
       PROCESSES.forall(p => 0.to(ledger.heightOf(p)-1).forall(i =>  ledger.entry(p, i).intersect(mempool.poolOf(p)).size()==0))
     }
 
     // INV3. every transaction in the mempool is valid
-    def inv3() = {
+    val inv3 = {
       PROCESSES.forall(p => mempool.poolOf(p).forall(t => ledger.isValid(p, t)))
     }
     
     // INV4. every transaction that appears in the mempool is eventually committed or forever invalid
-    // cannot be checked ftm. with Quint
-    // instead we consider the (weaker) invariant below
+    // temporal inv4 = {
+    //   PROCESSES.forall(p => mempool.get(p).forall(tx => eventually(ledger.isCommittedFor(p, tx) or always(not(ledger.isValid(p, tx))))))
+    // }
+    // FIXME. cannot be verified yet
+
+    // Instead, we use the (weaker) invariant below
     // INV4b. every transaction in hmempool is always committed or if valid then still in the mempool
-    def inv4() = {
-      PROCESSES.forall(p => hmempool.get(p).forall(tx => ledger.isCommittedFor(p, tx) or not(ledger.isValid(p, tx)) or mempool.poolOf(p).contains(tx)))
-    }
+     def inv4() = {
+       PROCESSES.forall(p => hmempool.get(p).forall(tx => ledger.isCommittedFor(p, tx) or not(ledger.isValid(p, tx)) or mempool.poolOf(p).contains(tx)))
+     }
 
-    def allInv = {inv1 and inv2 and inv3 and inv4}
+    val allInv = and {
+      inv1,
+      inv2,
+      inv3,
+      inv4
+   }
 
-    run moveHeightOnce = {
+    // 6. tests
+
+    run moveHeightOnceTest = {
       nondet p = oneOf(PROCESSES)
       nondet t = oneOf(TXS)
       init

--- a/quint/mempool/Spells.qnt
+++ b/quint/mempool/Spells.qnt
@@ -14,4 +14,8 @@ module Spells{
       m.keys().fold(Set(), (s, i) => s.union(Set(m.get(i))))
     }
 
+    pure def setChooseSome(s: Set[x]): x = {
+      head(s.fold(List(), (t,x) => t.append(x)))
+    }
+    
 }

--- a/quint/mempool/Spells.qnt
+++ b/quint/mempool/Spells.qnt
@@ -17,5 +17,9 @@ module Spells{
     pure def setChooseSome(s: Set[x]): x = {
       head(s.fold(List(), (t,x) => t.append(x)))
     }
+
+    pure def nonEmptyPowerset(s: Set[x]): Set[Set[x]] = {
+     s.powerset().exclude(Set(Set()))
+   }
     
 }

--- a/quint/mempool/Spells.qnt
+++ b/quint/mempool/Spells.qnt
@@ -1,0 +1,17 @@
+// -*- mode: Bluespec; -*-
+module Spells{
+    pure def require(cond: bool): bool = cond
+
+    pure def setEqualsOrOneEmpty(s: Set[x], t: Set[x]): bool = {
+      (s.size()==0 or t.size()==0) or s == t
+    }
+
+    pure def setSubsetOfAtMost(s: Set[x], max: int): Set[x] = {
+      if (max>=size(s)) s else oneOf(s.powerset().filter(u => size(u)==max))
+    }
+
+    pure def mapValues(m: x -> y): Set[y] = {
+      m.keys().fold(Set(), (s, i) => s.union(Set(m.get(i))))
+    }
+
+}

--- a/quint/mempool/Spells.qnt
+++ b/quint/mempool/Spells.qnt
@@ -19,7 +19,7 @@ module Spells{
     }
 
     pure def nonEmptyPowerset(s: Set[x]): Set[Set[x]] = {
-     s.powerset().exclude(Set(Set()))
-   }
+      s.powerset().exclude(Set(Set()))
+    }
     
 }

--- a/quint/mempool/System.qnt
+++ b/quint/mempool/System.qnt
@@ -1,0 +1,6 @@
+// -*- mode: Bluespec; -*-
+module System{
+    type Process = str
+    type Tx = str
+    type Block = Set[Tx]
+}

--- a/quint/mempool/System.qnt
+++ b/quint/mempool/System.qnt
@@ -3,4 +3,7 @@ module System{
     type Process = str
     type Tx = str
     type Block = Set[Tx]
+
+    pure val PROCESSES=Set("alice", "bob")
+    pure val TXS=Set("T0", "T1")
 }

--- a/quint/mempool/System.qnt
+++ b/quint/mempool/System.qnt
@@ -4,6 +4,6 @@ module System{
     type Tx = str
     type Block = Set[Tx]
 
-    pure val PROCESSES=Set("alice", "bob")
-    pure val TXS=Set("T0", "T1")
+    pure val PROCESSES=Set("alice", "bob", "charlie")
+    pure val TXS=Set("T0", "T1", "T2")
 }

--- a/quint/mempool/test.sh
+++ b/quint/mempool/test.sh
@@ -19,5 +19,3 @@ quint run --main LedgerTests --invariant invariant Ledger.qnt
 # mempool
 echo "moveHeightOnce" | quint -r Mempool.qnt::MempoolTests
 quint run --verbosity 3 --main MempoolTests --invariant allInv Mempool.qnt 
-
-

--- a/quint/mempool/test.sh
+++ b/quint/mempool/test.sh
@@ -1,21 +1,6 @@
 #!/bin/sh
 
-# consensus
-echo "
-proposeTwiceError
-decideNonProposedError
-decideProposedSuccess
-" | quint -r Consensus.qnt::ConsensusTests
-quint run --main ConsensusTests --invariant invariant Consensus.qnt 
-
-# ledger
-echo "
-submitTwiceError
-commitNonSubmittedError
-commitSubmittedSuccess
-" | quint -r Ledger.qnt::LedgerTests
-quint run --main LedgerTests --invariant invariant Ledger.qnt 
-
-# mempool
-echo "moveHeightOnce" | quint -r Mempool.qnt::MempoolTests
-quint run --verbosity 3 --main MempoolTests --invariant allInv Mempool.qnt 
+quint test Mempool.qnt
+quint run --init consensusInit --step consensusStep --invariant consensusInvariant Consensus.qnt
+quint run --init ledgerInit --step ledgerStep --invariant ledgerInvariant Ledger.qnt
+quint run --invariant allInv Mempool.qnt 

--- a/quint/mempool/test.sh
+++ b/quint/mempool/test.sh
@@ -3,4 +3,4 @@
 quint test Mempool.qnt
 quint run --init consensusInit --step consensusStep --invariant consensusInvariant Consensus.qnt
 quint run --init ledgerInit --step ledgerStep --invariant ledgerInvariant Ledger.qnt
-quint run --invariant allInv Mempool.qnt 
+quint run --max-steps 30 --invariant allInv --out-itf out.itf Mempool.qnt 

--- a/quint/mempool/test.sh
+++ b/quint/mempool/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# consensus
+echo "
+proposeTwiceError
+decideNonProposedError
+decideProposedSuccess
+" | quint -r Consensus.qnt::ConsensusTests
+quint run --main ConsensusTests --invariant invariant Consensus.qnt 
+
+# ledger
+echo "
+submitTwiceError
+commitNonSubmittedError
+commitSubmittedSuccess
+" | quint -r Ledger.qnt::LedgerTests
+quint run --main LedgerTests --invariant invariant Ledger.qnt 
+
+# mempool
+echo "moveHeightOnce" | quint -r Mempool.qnt::MempoolTests
+quint run --verbosity 3 --main MempoolTests --invariant allInv Mempool.qnt 
+
+


### PR DESCRIPTION
Add a [Quint](https://github.com/informalsystems/quint) specification for mempool, as defined [here](https://github.com/cometbft/knowledge-base/blob/main/protocols/mempool-overview.md).

Since both are needed, this PR also includes a specification for the [consensus](https://en.wikipedia.org/wiki/Consensus_(computer_science)) and [ledger](https://en.wikipedia.org/wiki/Distributed_ledger) abstractions.